### PR TITLE
Make LsuPeripheralAxiLite4 extra FF stages configurable

### DIFF
--- a/src/main/scala/naxriscv/lsu/LsuIoAxiLite4.scala
+++ b/src/main/scala/naxriscv/lsu/LsuIoAxiLite4.scala
@@ -6,18 +6,31 @@ import spinal.lib._
 import spinal.lib.bus.amba4.axi.Axi4SpecRenamer
 import spinal.lib.bus.amba4.axilite.AxiLite4SpecRenamer
 
-class LsuPeripheralAxiLite4(ioDataWidth : Int) extends Plugin{
+class LsuPeripheralAxiLite4(ioDataWidth : Int, 
+                            reg_stage_cmd : Boolean = false,
+                            reg_stage_ret: Boolean = true) extends Plugin{
   val logic = create late new Area{
     val cache = getService[LsuPlugin]
     val native = cache.peripheralBus.setAsDirectionLess
     val resized = native.resize(ioDataWidth)
     val axiRaw = resized.toAxiLite4()
     val axi = master(cloneOf(axiRaw))
-    axi.aw << axiRaw.aw.halfPipe()
-    axi.w  << axiRaw.w.halfPipe()
-    axi.b.halfPipe()  >> axiRaw.b
-    axi.ar << axiRaw.ar.halfPipe()
-    axi.r.halfPipe()  >> axiRaw.r
+    if (reg_stage_cmd) {
+      axi.aw << axiRaw.aw.halfPipe()
+      axi.w  << axiRaw.w.halfPipe()
+      axi.ar << axiRaw.ar.halfPipe()
+    } else {
+      axi.aw << axiRaw.aw
+      axi.w  << axiRaw.w
+      axi.ar << axiRaw.ar
+    }
+    if (reg_stage_ret) {
+      axi.b.halfPipe()  >> axiRaw.b
+      axi.r.halfPipe()  >> axiRaw.r
+    } else {
+      axi.b  >> axiRaw.b
+      axi.r  >> axiRaw.r
+    }
     AxiLite4SpecRenamer(axi)
   }
 }

--- a/src/main/scala/naxriscv/platform/Litex.scala
+++ b/src/main/scala/naxriscv/platform/Litex.scala
@@ -33,7 +33,8 @@ class NaxRiscvLitex(plugins : ArrayBuffer[Plugin], xlen : Int, toPeripheral : UI
     dataWidth = ramDataWidth
   )
   plugins += new LsuPeripheralAxiLite4(
-    ioDataWidth  = ioDataWidth
+    ioDataWidth  = ioDataWidth,
+    reg_stage    = false
   )
 
   val cpu = new NaxRiscv(

--- a/src/main/scala/naxriscv/platform/Litex.scala
+++ b/src/main/scala/naxriscv/platform/Litex.scala
@@ -33,8 +33,7 @@ class NaxRiscvLitex(plugins : ArrayBuffer[Plugin], xlen : Int, toPeripheral : UI
     dataWidth = ramDataWidth
   )
   plugins += new LsuPeripheralAxiLite4(
-    ioDataWidth  = ioDataWidth,
-    reg_stage    = false
+    ioDataWidth  = ioDataWidth
   )
 
   val cpu = new NaxRiscv(


### PR DESCRIPTION
This commit also changes the default to only buffer the return path.

It still reaches timing closure on the LiteX digilent_arty_s7.py target and reduces the pbus latency by one.


