### PR TITLE
LSU reworked to save Area

### DIFF
--- a/.github/workflows/tools.sh
+++ b/.github/workflows/tools.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 install_verilator(){
+  sudo apt-get update
   sudo apt install -y git make autoconf g++ flex libfl-dev bison  # First time prerequisites
   git clone http://git.veripool.org/git/verilator   # Only first time
   unset VERILATOR_ROOT  # For bash
@@ -40,6 +41,7 @@ install_elfio(){
 }
 
 install_packages(){
+  sudo apt-get update
   sudo apt install -y zlib1g-dev libboost-all-dev libboost-dev libasio-dev device-tree-compiler libsdl2-2.0-0 libsdl2-dev
 }
 

--- a/src/main/scala/naxriscv/Gen.scala
+++ b/src/main/scala/naxriscv/Gen.scala
@@ -446,6 +446,8 @@ object Gen extends App{
       withFloat = false,
       withDouble = false,
       withLsu2 = true,
+      lqSize = 16,
+      sqSize = 16,
       ioRange = a => a(31 downto 28) === 0x1// || !a(12)//(a(5, 6 bits) ^ a(12, 6 bits)) === 51
     )
     l.foreach{

--- a/src/main/scala/naxriscv/Gen.scala
+++ b/src/main/scala/naxriscv/Gen.scala
@@ -460,6 +460,7 @@ object Gen extends App{
   {
     val spinalConfig = SpinalConfig(inlineRom = true)
     spinalConfig.addTransformationPhase(new MemReadDuringWriteHazardPhase)
+    spinalConfig.addTransformationPhase(new MemReadDuringWritePatcherPhase)
     spinalConfig.addTransformationPhase(new MultiPortWritesSymplifier)
     //  spinalConfig.addTransformationPhase(new MultiPortReadSymplifier)
 
@@ -524,6 +525,7 @@ object Gen64 extends App{
   {
     val spinalConfig = SpinalConfig(inlineRom = true, anonymSignalPrefix = "_zz")
     spinalConfig.addTransformationPhase(new MemReadDuringWriteHazardPhase)
+    spinalConfig.addTransformationPhase(new MemReadDuringWritePatcherPhase)
     spinalConfig.addTransformationPhase(new MultiPortWritesSymplifier)
     //  spinalConfig.addTransformationPhase(new MultiPortReadSymplifier)
 

--- a/src/main/scala/naxriscv/Gen.scala
+++ b/src/main/scala/naxriscv/Gen.scala
@@ -242,10 +242,10 @@ object Config{
           sharedTranslationParameter = withMmu match {
             case false => StaticAddressTranslationParameter(rspAt = 2)
             case true => MmuPortParameter(
-              readAt = 1,
-              hitsAt = 1,
-              ctrlAt = 2,
-              rspAt  = 2
+              readAt = 0,
+              hitsAt = 0,
+              ctrlAt = 1,
+              rspAt  = 1
             )
           }
         )

--- a/src/main/scala/naxriscv/Gen.scala
+++ b/src/main/scala/naxriscv/Gen.scala
@@ -56,7 +56,7 @@ object Config{
               branchCount : Int = 16,
               withFloat  : Boolean = false,
               withDouble : Boolean = false,
-              withLsu2 : Boolean = false,
+              withLsu2 : Boolean = true,
               lqSize : Int = 16,
               sqSize : Int = 16,
               simulation : Boolean = GenerationFlags.simulation,

--- a/src/main/scala/naxriscv/Parameters.scala
+++ b/src/main/scala/naxriscv/Parameters.scala
@@ -17,7 +17,7 @@ object ROB extends AreaObject{
   val SIZE = NaxParameter[Int]
   def ID_WIDTH = log2Up(SIZE.get)
   val ID = Stageable(UInt(ID_WIDTH bits))
-  val MSB = Stageable(UInt(1 bits) //Extra ID bit which allow to figure out ordering by a substractor
+  val MSB = Stageable(UInt(1 bits)) //Extra ID bit which allow to figure out ordering by a substractor
   def lineRange = ID_WIDTH-1 downto log2Up(COLS)
 }
 

--- a/src/main/scala/naxriscv/Parameters.scala
+++ b/src/main/scala/naxriscv/Parameters.scala
@@ -17,6 +17,7 @@ object ROB extends AreaObject{
   val SIZE = NaxParameter[Int]
   def ID_WIDTH = log2Up(SIZE.get)
   val ID = Stageable(UInt(ID_WIDTH bits))
+  val MSB = Stageable(UInt(1 bits) //Extra ID bit which allow to figure out ordering by a substractor
   def lineRange = ID_WIDTH-1 downto log2Up(COLS)
 }
 

--- a/src/main/scala/naxriscv/compatibility/MultiportRam.scala
+++ b/src/main/scala/naxriscv/compatibility/MultiportRam.scala
@@ -187,7 +187,7 @@ class MultiPortWritesSymplifier(onlyTagged : Boolean = false) extends PhaseMemBl
   override def doBlackboxing(pc: PhaseContext, typo: MemTopology) : Unit = {
     if(onlyTagged && typo.mem.getTag(classOf[MultiPortWritesSymplifierTag]).isEmpty) return
 
-    if(typo.writes.size > 1 && typo.readsSync.size == 0){
+    if(typo.writes.size > 1 && typo.readsSync.size == 0 && typo.readsAsync.size != 0){
       typo.writes.foreach(w => assert(w.mask == null))
       typo.writes.foreach(w => assert(w.clockDomain == typo.writes.head.clockDomain))
       val cd = typo.writes.head.clockDomain
@@ -230,13 +230,12 @@ class MultiPortWritesSymplifier(onlyTagged : Boolean = false) extends PhaseMemBl
       ctx.foreach(_.restore())
     }
 
-    if(typo.writes.size > 1 && typo.readsAsync.size == 0){
+    if(typo.writes.size > 1 && typo.readsAsync.size == 0 && typo.readsSync.size != 0){
       typo.writes.foreach(w => assert(w.mask == null))
       typo.writes.foreach(w => assert(w.clockDomain == typo.writes.head.clockDomain))
       val cd = typo.writes.head.clockDomain
 
       import typo._
-
       val ctx = List(mem.parentScope.push(), cd.push())
 
       val c = RamSyncMwXor(

--- a/src/main/scala/naxriscv/execute/AguPlugin.scala
+++ b/src/main/scala/naxriscv/execute/AguPlugin.scala
@@ -31,6 +31,7 @@ class AguPlugin(val euId : String) extends Plugin{
 
     val port = lsu.newAguPort()
     eu.addRobStageable(lsu.keys.LSU_ID)
+    eu.addRobStageable(ROB.MSB)
     eu.setDecodingDefault(SEL, False)
 
     def add(microOp: MicroOp, srcKeys: List[SrcKeys], decoding: DecodeListType) = {
@@ -84,6 +85,7 @@ class AguPlugin(val euId : String) extends Plugin{
     setup.port.valid := isValid && SEL && !fired
     setup.port.address := U(SrcStageables.ADD_SUB).resized
     setup.port.robId := ROB.ID
+    setup.port.robIdMsb := ROB.MSB
     setup.port.size := U(func3(1 downto 0))
     setup.port.sc  := SC
     setup.port.amo := AMO

--- a/src/main/scala/naxriscv/execute/AguPlugin.scala
+++ b/src/main/scala/naxriscv/execute/AguPlugin.scala
@@ -49,9 +49,9 @@ class AguPlugin(val euId : String) extends Plugin{
     val stores = ArrayBuffer(Rvi.SB, Rvi.SH, Rvi.SW)
     if(XLEN.get == 64) stores ++= List(Rvi.SD)
 
-    for(store <- stores) add(store, srcOps, List(AMO -> False, SC -> False))
-    if(RVF) add(Rvfd.FSW, srcOps, List(AMO -> False, SC -> False))
-    if(RVD) add(Rvfd.FSD, srcOps, List(AMO -> False, SC -> False))
+    for(store <- stores) add(store, srcOps, List(AMO -> False, SC -> False, LOAD -> False))
+    if(RVF) add(Rvfd.FSW, srcOps, List(AMO -> False, SC -> False, LOAD -> False))
+    if(RVD) add(Rvfd.FSD, srcOps, List(AMO -> False, SC -> False, LOAD -> False))
 
     val amos = List(
       Rvi.AMOSWAP, Rvi.AMOADD, Rvi.AMOXOR, Rvi.AMOAND, Rvi.AMOOR,

--- a/src/main/scala/naxriscv/execute/AguPlugin.scala
+++ b/src/main/scala/naxriscv/execute/AguPlugin.scala
@@ -1,0 +1,115 @@
+package naxriscv.execute
+
+import naxriscv.Global.{PC, RVD, RVF, XLEN}
+import naxriscv.frontend._
+import naxriscv.interfaces.{DecoderService, MicroOp, RS1, RS2}
+import naxriscv.lsu2.Lsu2Plugin
+import naxriscv.riscv.{Const, FloatRegFile, IntRegFile, Rvfd, Rvi}
+import naxriscv.utilities._
+import naxriscv.{DecodeListType, Frontend, ROB}
+import spinal.core._
+import spinal.lib.pipeline._
+
+import scala.collection.mutable.ArrayBuffer
+
+
+object AguPlugin extends AreaObject{
+  val SEL = Stageable(Bool())
+  val AMO = Stageable(Bool())
+  val SC = Stageable(Bool())
+  val LR = Stageable(Bool())
+  val LOAD = Stageable(Bool())
+  val FLOAT = Stageable(Bool())
+}
+
+class AguPlugin(val euId : String) extends Plugin{
+  import AguPlugin._
+  val setup = create early new Area {
+    val eu = findService[ExecutionUnitBase](_.euId == euId)
+    val lsu = getService[Lsu2Plugin]
+    val rfDep = getService[RfDependencyPlugin]
+    eu.retain()
+
+    val port = lsu.newAguPort()
+    eu.addRobStageable(lsu.keys.LSU_ID)
+    eu.setDecodingDefault(SEL, False)
+
+    def add(microOp: MicroOp, srcKeys: List[SrcKeys], decoding: DecodeListType) = {
+      eu.addMicroOp(microOp)
+      eu.addDecoding(microOp, decoding :+ (SEL -> True))
+      if (srcKeys.nonEmpty) {
+        findService[SrcPlugin](_.euId == euId).specify(microOp, srcKeys)
+      }
+    }
+
+    val sk = SrcKeys
+
+    //Store section
+    val srcOps = List(sk.Op.ADD, sk.SRC1.RF, sk.SRC2.S)
+    val stores = ArrayBuffer(Rvi.SB, Rvi.SH, Rvi.SW)
+    if(XLEN.get == 64) stores ++= List(Rvi.SD)
+
+    for(store <- stores) add(store, srcOps, List(AMO -> False, SC -> False, FLOAT -> False))
+    if(RVF) add(Rvfd.FSW, srcOps, List(AMO -> False, SC -> False, FLOAT -> True))
+    if(RVD) add(Rvfd.FSD, srcOps, List(AMO -> False, SC -> False, FLOAT -> True))
+
+    val amos = List(
+      Rvi.AMOSWAP, Rvi.AMOADD, Rvi.AMOXOR, Rvi.AMOAND, Rvi.AMOOR,
+      Rvi.AMOMIN, Rvi.AMOMAX, Rvi.AMOMINU, Rvi.AMOMAXU
+    )
+    for(amo <- amos) add(amo, List(sk.Op.SRC1, sk.SRC1.RF), List(AMO -> True, SC -> False, LOAD -> False, FLOAT -> False))
+    add(Rvi.SC, List(sk.Op.SRC1, sk.SRC1.RF), List(AMO -> False, SC -> True, LOAD -> False, FLOAT -> False))
+
+
+//    val all = stores ++ amos ++ List(Rvi.SC)
+//    for(op <- all) rfDep.issueSkipRs(op, 1) //Handled by the LSU in oder to improve address checking
+
+    //Load section
+    val loads = ArrayBuffer(Rvi.LB , Rvi.LH , Rvi.LW , Rvi.LBU, Rvi.LHU)
+    if(XLEN.get == 64) loads ++= List(Rvi.LD, Rvi.LWU)
+    if(RVF) loads ++= List(Rvfd.FLW)
+    if(RVD) loads ++= List(Rvfd.FLD)
+
+    for(op <- loads) add(op, List(sk.Op.ADD, sk.SRC1.RF, sk.SRC2.I), List(LR -> False, LOAD -> True))
+    add(Rvi.LR,  List(sk.Op.SRC1, sk.SRC1.RF),  List(LR -> True, LOAD -> True))
+  }
+
+  val logic = create late new Area{
+    val lsu = getService[Lsu2Plugin]
+    val decoder = getService[DecoderService]
+    val eu = setup.eu
+    val stage = eu.getExecute(0)
+    import stage._
+    val func3 = Frontend.MICRO_OP(Const.funct3Range)
+    setup.port.valid := isFireing && SEL
+    setup.port.address := U(SrcStageables.ADD_SUB).resized
+    setup.port.robId := ROB.ID
+    setup.port.size := U(func3(1 downto 0))
+    setup.port.sc  := SC
+    setup.port.amo := AMO
+    setup.port.swap := Frontend.MICRO_OP(27)
+    setup.port.op  := Frontend.MICRO_OP(29, 3 bits)
+    setup.port.physicalRd := decoder.PHYS_RD
+    setup.port.regfileRd := decoder.REGFILE_RD
+    setup.port.writeRd := decoder.WRITE_RD
+
+    setup.port.aguId := lsu.keys.LSU_ID.resized
+    setup.port.unsigned := func3(2)
+    setup.port.pc := PC
+    setup.port.lr := LR
+    setup.port.load := LOAD
+
+    setup.port.data := eu.apply(IntRegFile, RS2).resized
+    if(RVF) when(FLOAT) {
+      setup.port.data := eu.apply(FloatRegFile, RS2).resized
+    }
+    eu.release()
+  }
+
+  val earlyPc = create late new Area{
+    val eu = findService[ExecutionUnitBase](_.euId == euId)
+    val stage = eu.pipeline.fetch(eu.pipeline.fetch.size-2)
+    setup.port.earlySample := stage.isReady
+    setup.port.earlyPc := stage(PC)
+  }
+}

--- a/src/main/scala/naxriscv/execute/AguPlugin.scala
+++ b/src/main/scala/naxriscv/execute/AguPlugin.scala
@@ -19,6 +19,7 @@ object AguPlugin extends AreaObject{
   val SC = Stageable(Bool())
   val LR = Stageable(Bool())
   val LOAD = Stageable(Bool())
+  val FLOAT = Stageable(Bool())
 }
 
 class AguPlugin(val euId : String) extends Plugin{
@@ -49,16 +50,16 @@ class AguPlugin(val euId : String) extends Plugin{
     val stores = ArrayBuffer(Rvi.SB, Rvi.SH, Rvi.SW)
     if(XLEN.get == 64) stores ++= List(Rvi.SD)
 
-    for(store <- stores) add(store, srcOps, List(AMO -> False, SC -> False, LOAD -> False))
-    if(RVF) add(Rvfd.FSW, srcOps, List(AMO -> False, SC -> False, LOAD -> False))
-    if(RVD) add(Rvfd.FSD, srcOps, List(AMO -> False, SC -> False, LOAD -> False))
+    for(store <- stores) add(store, srcOps, List(AMO -> False, SC -> False, LOAD -> False, FLOAT -> False))
+    if(RVF) add(Rvfd.FSW, srcOps, List(AMO -> False, SC -> False, LOAD -> False, FLOAT -> True))
+    if(RVD) add(Rvfd.FSD, srcOps, List(AMO -> False, SC -> False, LOAD -> False, FLOAT -> True))
 
     val amos = List(
       Rvi.AMOSWAP, Rvi.AMOADD, Rvi.AMOXOR, Rvi.AMOAND, Rvi.AMOOR,
       Rvi.AMOMIN, Rvi.AMOMAX, Rvi.AMOMINU, Rvi.AMOMAXU
     )
-    for(amo <- amos) add(amo, List(sk.Op.SRC1, sk.SRC1.RF), List(AMO -> True, SC -> False, LOAD -> False))
-    add(Rvi.SC, List(sk.Op.SRC1, sk.SRC1.RF), List(AMO -> False, SC -> True, LOAD -> False))
+    for(amo <- amos) add(amo, List(sk.Op.SRC1, sk.SRC1.RF), List(AMO -> True, SC -> False, LOAD -> False, FLOAT -> False))
+    add(Rvi.SC, List(sk.Op.SRC1, sk.SRC1.RF), List(AMO -> False, SC -> True, LOAD -> False, FLOAT -> False))
 
 
 //    val all = stores ++ amos ++ List(Rvi.SC)
@@ -102,7 +103,7 @@ class AguPlugin(val euId : String) extends Plugin{
     setup.port.load := LOAD
 
     setup.port.data := eu.apply(IntRegFile, RS2).resized
-    if(RVF) when(decoder.REGFILE_RS(RS2) === decoder.REGFILE_RS(RS2).rfToId(FloatRegFile)) {
+    if(RVF) when(FLOAT) {
       setup.port.data := eu.apply(FloatRegFile, RS2).resized
     }
     eu.release()

--- a/src/main/scala/naxriscv/execute/EnvCallPlugin.scala
+++ b/src/main/scala/naxriscv/execute/EnvCallPlugin.scala
@@ -4,7 +4,7 @@ import naxriscv.Global._
 import naxriscv.fetch.{FetchCachePlugin, FetchPlugin}
 import naxriscv.frontend.DispatchPlugin
 import naxriscv.interfaces.{AddressTranslationService, CommitService, DecoderService, MicroOp, ScheduleReason}
-import naxriscv.lsu.LsuPlugin
+import naxriscv.lsu.{LsuFlusher, LsuPlugin}
 import naxriscv.misc.PrivilegedPlugin
 import naxriscv.riscv.{CSR, Const, Rvi}
 import naxriscv.utilities._
@@ -109,8 +109,8 @@ class EnvCallPlugin(val euId : String)(var rescheduleAt : Int = 0) extends Plugi
     val flushes = new StateMachine{
       val vmaPort = getService[AddressTranslationService].invalidatePort
       val fetchPort = getService[FetchCachePlugin].invalidatePort
-      val lsuPort   = getServiceOption[LsuPlugin] match {
-        case Some(lsu) => lsu.flushPort
+      val lsuPort   = getServiceOption[LsuFlusher] match {
+        case Some(lsu) => lsu.getFlushPort()
         case None => println("No LSU plugin for the EnvCallPlugin flush ???"); null
       }
 

--- a/src/main/scala/naxriscv/fetch/FetchCachePlugin.scala
+++ b/src/main/scala/naxriscv/fetch/FetchCachePlugin.scala
@@ -270,7 +270,8 @@ class FetchCachePlugin(var cacheSize : Int,
 
     val translationPort = translation.newTranslationPort(
       stages = fetch.pipeline.stages,
-      preAddress = FETCH_PC,
+      preAddress  = FETCH_PC,
+      allowRefill = null,
       usage = AddressTranslationPortUsage.FETCH,
       portSpec = translationPortParameter,
       storageSpec = setup.translationStorage

--- a/src/main/scala/naxriscv/frontend/DecoderPlugin.scala
+++ b/src/main/scala/naxriscv/frontend/DecoderPlugin.scala
@@ -223,6 +223,8 @@ class DecoderPlugin(xlen : Int) extends Plugin with DecoderService with LockedIm
           case FPU => fpSpec.addNeeds(key, one)
           case RM => rmSpec.addNeeds(key, one)
           case r if resourceToStageable.contains(r) => resourceToSpec(r).addNeeds(key, one)
+          case naxriscv.interfaces.SQ =>
+          case naxriscv.interfaces.LQ =>
         }
       }
 

--- a/src/main/scala/naxriscv/interfaces/Service.scala
+++ b/src/main/scala/naxriscv/interfaces/Service.scala
@@ -401,6 +401,7 @@ trait AddressTranslationService extends Service with LockedImpl {
   def newStorage(pAny: Any) : Any
   def newTranslationPort(stages: Seq[Stage],
                          preAddress: Stageable[UInt],
+                         allowRefill : Stageable[Bool],
                          usage: AddressTranslationPortUsage,
                          portSpec: Any,
                          storageSpec: Any): AddressTranslationRsp

--- a/src/main/scala/naxriscv/lsu/LsuIoAxiLite4.scala
+++ b/src/main/scala/naxriscv/lsu/LsuIoAxiLite4.scala
@@ -1,5 +1,6 @@
 package naxriscv.lsu
 
+import naxriscv.lsu2.Lsu2Plugin
 import naxriscv.utilities.Plugin
 import spinal.core._
 import spinal.lib._
@@ -10,8 +11,8 @@ class LsuPeripheralAxiLite4(ioDataWidth : Int,
                             reg_stage_cmd : Boolean = false,
                             reg_stage_ret: Boolean = true) extends Plugin{
   val logic = create late new Area{
-    val cache = getService[LsuPlugin]
-    val native = cache.peripheralBus.setAsDirectionLess
+    val peripheralBus = getServiceOption[LsuPlugin].map(_.peripheralBus).getOrElse(getServiceOption[Lsu2Plugin].map(_.peripheralBus).get)
+    val native = peripheralBus.setAsDirectionLess
     val resized = native.resize(ioDataWidth)
     val axiRaw = resized.toAxiLite4()
     val axi = master(cloneOf(axiRaw))

--- a/src/main/scala/naxriscv/lsu2/Lsu2Plugin.scala
+++ b/src/main/scala/naxriscv/lsu2/Lsu2Plugin.scala
@@ -1,0 +1,307 @@
+package naxriscv.lsu2
+
+import naxriscv.Frontend._
+import naxriscv.Global._
+import naxriscv.fetch.FetchPlugin
+import naxriscv.frontend.{DispatchPlugin, FrontendPlugin}
+import naxriscv.{Frontend, Global, ROB}
+import naxriscv.interfaces._
+import naxriscv.lsu.{DataCachePlugin, LsuUtils}
+import naxriscv.misc.RobPlugin
+import naxriscv.riscv.Rvi
+import spinal.core._
+import spinal.lib._
+import naxriscv.utilities.{DocPlugin, Plugin, WithRfWriteSharedSpec}
+import spinal.lib.pipeline._
+import scala.collection.mutable.ArrayBuffer
+
+/*
+
+ */
+
+case class AguPort(aguIdSize : Int,
+                   wordWidth : Int,
+                   physicalRdWidth : Int,
+                   regfileRdWidth : Int,
+                   pcWidth : Int) extends Bundle {
+  val robId = ROB.ID()
+  val aguId = UInt(log2Up(aguIdSize) bits)
+  val load = Bool()
+  val address = UInt(VIRTUAL_EXT_WIDTH bits)
+  val size = UInt(log2Up(log2Up(wordWidth/8)+1) bits)
+  val unsigned = Bool()
+  val physicalRd = UInt(physicalRdWidth bits)
+  val regfileRd = UInt(regfileRdWidth bits)
+  val writeRd = Bool()
+  val pc = UInt(pcWidth bits)
+  val lr = Bool()
+
+  val earlySample = Bool()
+  val earlyPc = UInt(pcWidth bits) //One cycle early pc, to fetch prediction
+
+  val data  = Bits(wordWidth bits)
+
+  //Atomic stuff
+  val amo = Bool()
+  val sc = Bool()
+  val swap = Bool()
+  val op  = Bits(3 bits)
+}
+
+
+class Lsu2Plugin(var lqSize: Int,
+                 var sqSize : Int,
+                 var translationStorageParameter : Any,
+                 var loadTranslationParameter : Any,
+                 var storeReadRfWithBypass : Boolean = false) extends Plugin with PostCommitBusy with WithRfWriteSharedSpec{
+
+
+  def wordWidth = LSLEN
+  def wordBytes = wordWidth/8
+  def wordSizeWidth = LsuUtils.sizeWidth(wordWidth)
+  def pageOffsetRange = 11 downto log2Up(wordBytes)
+  def pageNumberRange = Global.XLEN.get-1 downto 12
+  def pageOffsetWidth = pageOffsetRange.size
+  def pageNumberWidth = pageNumberRange.size
+  override def postCommitBusy = setup.postCommitBusy
+
+  case class AguPortSpec(port : Flow[AguPort])
+  val aguPorts = ArrayBuffer[AguPortSpec]()
+  def newAguPort(): Flow[AguPort] = {
+    aguPorts.addRet(AguPortSpec(Flow(AguPort(
+      aguIdSize       = sqSize max lqSize,
+      wordWidth       = wordWidth,
+      physicalRdWidth = widthOf(getService[DecoderService].PHYS_RD),
+      regfileRdWidth  = widthOf(getService[DecoderService].REGFILE_RD),
+      pcWidth         = VIRTUAL_EXT_WIDTH
+    )))).port
+  }
+
+  val keys = new AreaRoot{
+    val SQ_ALLOC = Stageable(Bool())
+    val LQ_ALLOC = Stageable(Bool())
+    val LSU_ID = Stageable(UInt(log2Up(lqSize max sqSize) bits))
+    val SIZE = Stageable(UInt(wordSizeWidth bits))
+    val UNSIGNED = Stageable(Bool())
+    val WRITE_RD = Stageable(Bool())
+    val LQ_SEL = Stageable(UInt(log2Up(lqSize) bits))
+    val LQ_SEL_OH = Stageable(Bits(lqSize bits))
+    val SQ_SEL = Stageable(UInt(log2Up(sqSize) bits))
+    val SQ_SEL_OH = Stageable(Bits(sqSize bits))
+    val ADDRESS_PRE_TRANSLATION = Stageable(UInt(VIRTUAL_EXT_WIDTH bits))
+    val DATA_MASK = Stageable(Bits(wordBytes bits))
+
+
+    val LQ_ID = Stageable(UInt(log2Up(lqSize + 1) bits))
+    val SQ_ID = Stageable(UInt(log2Up(sqSize + 1) bits))
+  }
+  import keys._
+
+
+  val setup = create early new Area{
+    val rob = getService[RobPlugin]
+    val decoder = getService[DecoderService]
+    val frontend = getService[FrontendPlugin]
+    val cache = getService[DataCachePlugin]
+    val regfiles = getServicesOf[RegfileService]
+    val commit = getService[CommitService]
+    val translation = getService[AddressTranslationService]
+    val doc = getService[DocPlugin]
+    val dispatch = getService[DispatchPlugin]
+    val fetch = getService[FetchPlugin]
+    val postCommitBusy = Bool()
+
+
+    rob.retain()
+    decoder.retain()
+    frontend.retain()
+    translation.retain()
+    fetch.retain()
+
+    getServiceOption[PrivilegedService].foreach(_.addMisa('A'))
+
+    val amos = List(
+      Rvi.AMOSWAP, Rvi.AMOADD, Rvi.AMOXOR, Rvi.AMOAND, Rvi.AMOOR,
+      Rvi.AMOMIN, Rvi.AMOMAX, Rvi.AMOMINU, Rvi.AMOMAXU
+    )
+    amos.foreach(dispatch.fenceYounger(_))
+    dispatch.fenceOlder  (Rvi.LR)
+    dispatch.fenceYounger(Rvi.SC)
+    dispatch.fenceOlder  (Rvi.SC)
+
+
+    class RegfilePorts(regfile : RegfileService) extends Area{
+      val read = regfile.newRead(withReady = false, forceNoBypass = !storeReadRfWithBypass)
+      val sharing = getRfWriteSharing(regfile.rfSpec)
+      assert(sharing.withReady == false)
+      val write = regfile.newWrite(false, 0, sharing.key, sharing.priority)
+    }
+    val regfilePorts = (for(regfile <- regfiles) yield regfile.rfSpec -> new RegfilePorts(regfile)).toMapLinked()
+    val cacheLoad = cache.newLoadPort(priority = 0)
+    val cacheStore = cache.newStorePort()
+  }
+
+  val logic = create late new Area{
+    val imp = setup.get
+    import imp._
+
+    val lq = new Area{
+      val replay = Reg(Bits(lqSize bits)) init(0)
+      val regs = List.tabulate(lqSize)(RegType)
+      case class RegType(id : Int) extends Area{
+        val allocation = False
+        val valid = Bool()
+//        val waitOn = new Area {
+//          val cacheRefill    = Reg(Bits(cache.refillCount bits))
+//          val cacheRefillAny = Reg(Bool())
+//          val mmuRefill      = Reg(Bool())
+//          val sq             = Reg(Bool())
+//          val sqCompletion = Reg(Bool())
+//          val sqId   = Reg(SQ_ID)
+//          val sqPredicted = withHazardPrediction generate Reg(Bool())
+//        }
+
+        when(allocation){
+          valid := True
+        }
+      }
+
+      val ptr = new Area{
+        val alloc, free = Reg(UInt(log2Up(lqSize) + 1 bits)) init (0)
+        val allocReal = U(alloc.dropHigh(1))
+        val freeReal = U(free.dropHigh(1))
+      }
+
+      val tracker = new Area{
+        val freeNext = UInt(log2Up(lqSize+1) bits)
+        val free = RegNext(freeNext) init (lqSize)
+        val freeReduced = RegNext(freeNext.sat(widthOf(freeNext)-log2Up(DECODE_COUNT.get+1)))
+        val add = UInt(log2Up(COMMIT_COUNT.get+1) bits)
+        val sub = UInt(log2Up(DECODE_COUNT.get+1) bits)
+        freeNext := free + add - sub
+
+        val clear = False
+        when(clear){
+          freeNext := lqSize
+        }
+      }
+    }
+
+
+    val sq = new Area{
+      val replay = Reg(Bits(sqSize bits)) init(0)
+      val regs = List.tabulate(sqSize)(RegType)
+      case class RegType(id : Int) extends Area{
+        val allocation = False
+        val valid = Bool()
+        //        val waitOn = new Area {
+        //          val cacheRefill    = Reg(Bits(cache.refillCount bits))
+        //          val cacheRefillAny = Reg(Bool())
+        //          val mmuRefill      = Reg(Bool())
+        //          val sq             = Reg(Bool())
+        //          val sqCompletion = Reg(Bool())
+        //          val sqId   = Reg(SQ_ID)
+        //          val sqPredicted = withHazardPrediction generate Reg(Bool())
+        //        }
+
+        when(allocation){
+          valid := True
+        }
+      }
+
+      val ptr = new Area{
+        val alloc, commit, writeBack, free = Reg(UInt(log2Up(sqSize) + 1 bits)) init(0)
+        val allocReal = U(alloc.dropHigh(1))
+        val freeReal = U(free.dropHigh(1))
+        val writeBackReal = U(writeBack.dropHigh(1))
+        val commitReal = U(commit.dropHigh(1))
+        val commitNext = cloneOf(commit)
+        commit := commitNext
+//        def isFull(ptr : UInt) = (ptr ^ free) === sqSize
+//        def isFree(ptr : UInt) = (free - ptr) < sqSize
+
+        val onFree = Flow(UInt(log2Up(sqSize) bits))
+        val onFreeLast = onFree.stage()
+
+        setup.postCommitBusy setWhen(commit =/= free)
+      }
+
+      val tracker = new Area{
+        val freeNext = UInt(log2Up(sqSize+1) bits)
+        val free = RegNext(freeNext) init (sqSize)
+        val freeReduced = RegNext(freeNext.sat(widthOf(freeNext)-log2Up(DECODE_COUNT.get+1)))
+        val add = UInt(1 bits)
+        val sub = UInt(log2Up(DECODE_COUNT.get+1) bits)
+        freeNext := sqSize + ptr.free - ptr.alloc - sub + add
+      }
+
+    }
+
+
+    val allocation = new Area{
+      val allocStage = frontend.pipeline.dispatch
+      for(slotId <- 0 until Frontend.DISPATCH_COUNT){
+        allocStage(LSU_ID, slotId).assignDontCare()
+      }
+
+      import allocStage._
+
+      val loads = new Area {
+        val requests = (0 until Frontend.DISPATCH_COUNT).map(id => (DISPATCH_MASK, id) && (LQ_ALLOC, id))
+        val requestsCount = CountOne(requests)
+        val full = lq.tracker.freeReduced < requestsCount
+        var alloc = CombInit(lq.ptr.alloc)
+      }
+      val stores = new Area {
+        val requests = (0 until Frontend.DISPATCH_COUNT).map(id => (DISPATCH_MASK, id) && (SQ_ALLOC, id))
+        val requestsCount = CountOne(requests)
+        val full = sq.tracker.freeReduced < requestsCount
+        var alloc = CombInit(sq.ptr.alloc)
+      }
+
+      haltIt(isValid && (loads.full || stores.full) )
+
+      for(slotId <- 0 until Frontend.DISPATCH_COUNT){
+        implicit val _ = StageableOffset(slotId)
+        LQ_ID := loads.alloc
+        SQ_ID := stores.alloc
+        when(loads.requests(slotId)){
+          LSU_ID := loads.alloc
+          when(isFireing) {
+            lq.regs.map(_.allocation).write(LQ_ID, True)
+//            mem.sqAlloc.write(
+//              address = LQ_ID,
+//              data = U(SQ_ID_CARRY ## allocStage(SQ_ID, slotId))
+//            )
+          }
+          loads.alloc \= loads.alloc + 1
+        }
+        when(stores.requests(slotId)){
+          LSU_ID := stores.alloc
+          when(isFireing) {
+            //...
+          }
+          stores.alloc \= stores.alloc + 1
+        }
+      }
+      lq.tracker.sub := 0
+      sq.tracker.sub := 0
+      when(isFireing){
+        lq.ptr.alloc := loads.alloc
+        sq.ptr.alloc := stores.alloc
+        lq.tracker.sub := loads.requestsCount
+        sq.tracker.sub := stores.requestsCount
+      }
+    }
+
+    val sharedPip = new Pipeline{
+
+    }
+
+    rob.release()
+    decoder.release()
+    frontend.release()
+    fetch.release()
+    translation.release()
+  }
+}

--- a/src/main/scala/naxriscv/lsu2/Lsu2Plugin.scala
+++ b/src/main/scala/naxriscv/lsu2/Lsu2Plugin.scala
@@ -659,11 +659,9 @@ class Lsu2Plugin(var lqSize: Int,
       }
 
       val hazardPrediction = withHazardPrediction generate new Area{
-        val read = lq.hazardPrediction.mem.readSyncPort
+        val read = lq.hazardPrediction.mem.readSyncPort(readUnderWrite = eitherFirst)
         read.cmd.valid := port.earlySample
         read.cmd.payload := lq.hazardPrediction.index(port.earlyPc)
-
-        lq.hazardPrediction.addHazard(read.cmd)
 
         val hash = lq.hazardPrediction.hash(port.pc)
         val hit = read.rsp.score =/= 0 && read.rsp.tag === hash
@@ -672,10 +670,9 @@ class Lsu2Plugin(var lqSize: Int,
       }
 
       val hitPrediction = new Area{
-        val read = lq.hitPrediction.mem.readSyncPort
+        val read = lq.hitPrediction.mem.readSyncPort(readUnderWrite = eitherFirst)
         read.cmd.valid := port.earlySample
         read.cmd.payload := lq.hitPrediction.index(port.earlyPc)
-        lq.hitPrediction.addHazard(read.cmd)
 
         def write = lq.hitPrediction.write
 

--- a/src/main/scala/naxriscv/lsu2/Lsu2Plugin.scala
+++ b/src/main/scala/naxriscv/lsu2/Lsu2Plugin.scala
@@ -4,6 +4,7 @@ import naxriscv.Frontend._
 import naxriscv.Global._
 import naxriscv.fetch.FetchPlugin
 import naxriscv.frontend.{DispatchPlugin, FrontendPlugin}
+import naxriscv.interfaces.AddressTranslationPortUsage.LOAD_STORE
 import naxriscv.{Frontend, Global, ROB}
 import naxriscv.interfaces._
 import naxriscv.lsu.{DataCachePlugin, LsuUtils}
@@ -12,11 +13,27 @@ import naxriscv.riscv.Rvi
 import spinal.core._
 import spinal.lib._
 import naxriscv.utilities.{DocPlugin, Plugin, WithRfWriteSharedSpec}
+import spinal.lib.pipeline.Connection.M2S
 import spinal.lib.pipeline._
+
 import scala.collection.mutable.ArrayBuffer
 
 /*
+vs the original LsuPlugin :
 
+Pipeline rework ->
+- Use the issue queue / EU0 to track depdencies and provide the data to store (greatly reducing area)
+  So, no more store data fetch and store completion pipeline
+- Load and store address pipeline are now fused, avoiding duplicating MMU ports. This will also allow store prefetch
+
+Out of oder rework ->
+- Store to load bypass info will be provided via a predictor instead of a CAM, reducing the need to have early address
+- Store to load hazard will be checked via re-execution of the load
+- To reduce load re-execution, a store vulnerability window filter is added
+- Load to load on the same address ordering (snoop / line refill) will be on the side of the re-execution filter
+
+Overall it should save quite a lot of area, and also reduce timings pressure (no CAM).
+Also increasing LQ/SQ size will have much less impact on area and timings.
  */
 
 case class AguPort(aguIdSize : Int,
@@ -53,6 +70,9 @@ class Lsu2Plugin(var lqSize: Int,
                  var sqSize : Int,
                  var translationStorageParameter : Any,
                  var loadTranslationParameter : Any,
+                 var sharedFeedAt : Int = 1, //Stage at which the d$ cmd is sent
+                 var sharedCtrlAt : Int = 4,
+                 var lqToCachePipelined : Boolean = true,
                  var storeReadRfWithBypass : Boolean = false) extends Plugin with PostCommitBusy with WithRfWriteSharedSpec{
 
 
@@ -69,7 +89,7 @@ class Lsu2Plugin(var lqSize: Int,
   val aguPorts = ArrayBuffer[AguPortSpec]()
   def newAguPort(): Flow[AguPort] = {
     aguPorts.addRet(AguPortSpec(Flow(AguPort(
-      aguIdSize       = sqSize max lqSize,
+      aguIdSize       = (sqSize max lqSize)+1,
       wordWidth       = wordWidth,
       physicalRdWidth = widthOf(getService[DecoderService].PHYS_RD),
       regfileRdWidth  = widthOf(getService[DecoderService].REGFILE_RD),
@@ -80,7 +100,7 @@ class Lsu2Plugin(var lqSize: Int,
   val keys = new AreaRoot{
     val SQ_ALLOC = Stageable(Bool())
     val LQ_ALLOC = Stageable(Bool())
-    val LSU_ID = Stageable(UInt(log2Up(lqSize max sqSize) bits))
+    val LSU_ID = Stageable(UInt(log2Up(lqSize max sqSize)+1 bits))
     val SIZE = Stageable(UInt(wordSizeWidth bits))
     val UNSIGNED = Stageable(Bool())
     val WRITE_RD = Stageable(Bool())
@@ -92,8 +112,15 @@ class Lsu2Plugin(var lqSize: Int,
     val DATA_MASK = Stageable(Bits(wordBytes bits))
 
 
+    val LQ_HIT = Stageable(Bool())
+    val SQ_HIT = Stageable(Bool())
+
     val LQ_ID = Stageable(UInt(log2Up(lqSize + 1) bits))
     val SQ_ID = Stageable(UInt(log2Up(sqSize + 1) bits))
+
+
+    val LQ_SQ_ID = Stageable(UInt(log2Up(sqSize) + 1 bits))
+    val LQ_OLDER_THAN_SQ = Stageable(Bool())
   }
   import keys._
 
@@ -139,18 +166,21 @@ class Lsu2Plugin(var lqSize: Int,
     val regfilePorts = (for(regfile <- regfiles) yield regfile.rfSpec -> new RegfilePorts(regfile)).toMapLinked()
     val cacheLoad = cache.newLoadPort(priority = 0)
     val cacheStore = cache.newStorePort()
+    val translationStorage = translation.newStorage(translationStorageParameter)
   }
 
   val logic = create late new Area{
     val imp = setup.get
     import imp._
 
+    val rescheduling = commit.reschedulingPort(onCommit = true)
+
     val lq = new Area{
-      val replay = Reg(Bits(lqSize bits)) init(0)
       val regs = List.tabulate(lqSize)(RegType)
       case class RegType(id : Int) extends Area{
         val allocation = False
-        val valid = Bool()
+        val valid = RegInit(False)
+        val redo = RegInit(False)
 //        val waitOn = new Area {
 //          val cacheRefill    = Reg(Bits(cache.refillCount bits))
 //          val cacheRefillAny = Reg(Bool())
@@ -166,7 +196,22 @@ class Lsu2Plugin(var lqSize: Int,
         }
       }
 
+      val mem = new Area{
+        def create[T <: Data](t : HardType[T]) = Mem.fill(lqSize)(t)
+        val addressPre  = create(UInt(VIRTUAL_EXT_WIDTH bits))
+        val addressPost = create(UInt(PHYSICAL_WIDTH bits))
+        val physRd      = create(decoder.PHYS_RD)
+        val regfileRd   = create(decoder.REGFILE_RD)
+        val robId       = create(ROB.ID)
+        val pc          = create(PC)
+        val sqAlloc     = create(UInt(log2Up(sqSize)+1 bits))
+        val io          = create(Bool())
+        val writeRd     = create(Bool())
+        val lr          = create(Bool())
+      }
+
       val ptr = new Area{
+        val priority = Reg(Bits(lqSize-1 bits)) init(0) //TODO
         val alloc, free = Reg(UInt(log2Up(lqSize) + 1 bits)) init (0)
         val allocReal = U(alloc.dropHigh(1))
         val freeReal = U(free.dropHigh(1))
@@ -189,11 +234,11 @@ class Lsu2Plugin(var lqSize: Int,
 
 
     val sq = new Area{
-      val replay = Reg(Bits(sqSize bits)) init(0)
       val regs = List.tabulate(sqSize)(RegType)
       case class RegType(id : Int) extends Area{
         val allocation = False
         val valid = Bool()
+        val redo = RegInit(False)
         //        val waitOn = new Area {
         //          val cacheRefill    = Reg(Bits(cache.refillCount bits))
         //          val cacheRefillAny = Reg(Bool())
@@ -209,7 +254,14 @@ class Lsu2Plugin(var lqSize: Int,
         }
       }
 
+
+      val mem = new Area{
+        def create[T <: Data](t : HardType[T]) = Mem.fill(sqSize)(t)
+        val sqIdMsb          = create(Bool())
+      }
+
       val ptr = new Area{
+        val priority = Reg(Bits(sqSize-1 bits)) init(0) //TODO
         val alloc, commit, writeBack, free = Reg(UInt(log2Up(sqSize) + 1 bits)) init(0)
         val allocReal = U(alloc.dropHigh(1))
         val freeReal = U(free.dropHigh(1))
@@ -268,18 +320,22 @@ class Lsu2Plugin(var lqSize: Int,
         when(loads.requests(slotId)){
           LSU_ID := loads.alloc
           when(isFireing) {
-            lq.regs.map(_.allocation).write(LQ_ID, True)
-//            mem.sqAlloc.write(
-//              address = LQ_ID,
-//              data = U(SQ_ID_CARRY ## allocStage(SQ_ID, slotId))
-//            )
+            lq.regs.onSel(LQ_ID){ e =>
+              e.allocation := True
+            }
+            lq.mem.sqAlloc.write(
+              address = LQ_ID,
+              data    = allocStage(SQ_ID, slotId)
+            )
           }
           loads.alloc \= loads.alloc + 1
         }
         when(stores.requests(slotId)){
           LSU_ID := stores.alloc
           when(isFireing) {
-            //...
+            def wr[T <: Data](mem: Mem[T], data : T) = mem.write(SQ_ID, data)
+            wr(sq.mem.sqIdMsb, allocStage(SQ_ID, slotId).msb)
+
           }
           stores.alloc \= stores.alloc + 1
         }
@@ -295,7 +351,89 @@ class Lsu2Plugin(var lqSize: Int,
     }
 
     val sharedPip = new Pipeline{
+      val stages = Array.fill(sharedCtrlAt+1)(newStage())
+      connect(stages)(List(M2S()))
+      stages.last.flushIt(rescheduling.valid, root = false)
 
+      val translationPort = translation.newTranslationPort(
+        stages = this.stages,
+        preAddress = ADDRESS_PRE_TRANSLATION,
+        usage = LOAD_STORE,
+        portSpec = loadTranslationParameter,
+        storageSpec = setup.translationStorage
+      )
+      val tpk = translationPort.keys
+
+      val arbitration = new Area{
+        val stage = stages(0)
+        import stage._
+
+        val lqRedo = B(lq.regs.map(reg => reg.redo))
+        val sqRedo = B(sq.regs.map(reg => reg.redo))
+
+        LQ_SEL_OH := OHMasking.roundRobinMasked(lqRedo, lq.ptr.priority)
+        SQ_SEL_OH := OHMasking.roundRobinMasked(sqRedo, sq.ptr.priority)
+        LQ_HIT := LQ_SEL_OH.orR
+        SQ_HIT := SQ_SEL_OH.orR
+        LQ_SEL := OHToUInt(LQ_SEL_OH)
+        SQ_SEL := OHToUInt(SQ_SEL_OH)
+
+        isValid := LQ_HIT || SQ_HIT
+
+        LQ_SQ_ID := lq.mem.sqAlloc.readAsync(LQ_SEL)
+        SQ_ID := U(sq.mem.sqIdMsb.readAsync(LQ_SEL) ## SQ_ID)
+        LQ_OLDER_THAN_SQ := LQ_HIT && !(SQ_ID - LQ_SQ_ID).msb
+
+      }
+
+      val feed = new Area {
+        val stage = stages(sharedFeedAt)
+        import stage._
+
+        val agu = aguPorts.head.port
+        val takeAgu = agu.robId
+
+        //Get the oldest load in the LQ ready for the cache access
+        val arbitration = new Area {
+          def area(hits : Bits, priority : Bits)(onFire : Bits => Unit) = new Area{
+            case class Payload() extends Bundle {
+              val selOh = Bits(lqSize bits)
+              val sel = UInt(log2Up(lqSize) bits)
+            }
+
+            val selOh = OHMasking.roundRobinMasked(hits, priority)
+            val output = Stream(Payload())
+            output.valid := hits.orR
+            output.selOh := selOh
+            output.sel := OHToUInt(selOh)
+            when(output.fire) {
+              onFire(selOh)
+            }
+          }
+          val lqSource = area(B(lq.regs.map(reg => reg.redo)), lq.ptr.priority){mask =>
+            lq.regs.onMask(mask){ reg =>
+              reg.redo := False
+            }
+          }
+          val sqSource = area(B(sq.regs.map(reg => reg.redo)), sq.ptr.priority){mask =>
+            sq.regs.onMask(mask){ reg =>
+              reg.redo := False
+            }
+          }
+
+//          when(output.fire) {
+//            lq.regs.onMask(selOh){ reg =>
+//              reg.redo := False
+//            }
+//          }
+//
+//          val output = if (lqToCachePipelined) early.m2sPipe(flush = stages.head.isFlushed) else early.combStage()
+//
+//          def outputSel = output.sel //OHToUInt(output.payload)
+        }
+
+//        isValid := arbitration.output.valid
+      }
     }
 
     rob.release()

--- a/src/main/scala/naxriscv/misc/CommitPlugin.scala
+++ b/src/main/scala/naxriscv/misc/CommitPlugin.scala
@@ -86,6 +86,7 @@ class CommitPlugin(var commitCount : Int,
       val frontend = getService[FrontendPlugin]
       val stage = frontend.pipeline.allocated
       stage(ROB.ID) := alloc.resized
+      stage(ROB.MSB) := U(alloc.msb)
       stage.haltIt(full)
 
       allocNext := alloc + (stage.isFireing ? U(ROB.COLS) | U(0))

--- a/src/main/scala/naxriscv/misc/CommitPlugin.scala
+++ b/src/main/scala/naxriscv/misc/CommitPlugin.scala
@@ -51,6 +51,7 @@ class CommitPlugin(var commitCount : Int,
     val rob = getService[RobService]
     val robLineMask = rob.newRobLineValids(bypass = ptrCommitRetimed)
     val isRobEmpty = Bool()
+    getService[DecoderService].addDecodingToRob(ROB.MSB)
     rob.retain()
   }
 
@@ -86,7 +87,7 @@ class CommitPlugin(var commitCount : Int,
       val frontend = getService[FrontendPlugin]
       val stage = frontend.pipeline.allocated
       stage(ROB.ID) := alloc.resized
-      stage(ROB.MSB) := U(alloc.msb)
+      for(i <- 0 until DISPATCH_COUNT) stage(ROB.MSB, i) := U(alloc.msb)
       stage.haltIt(full)
 
       allocNext := alloc + (stage.isFireing ? U(ROB.COLS) | U(0))

--- a/src/main/scala/naxriscv/misc/MmuPlugin.scala
+++ b/src/main/scala/naxriscv/misc/MmuPlugin.scala
@@ -94,6 +94,7 @@ class MmuPlugin(var spec : MmuSpec,
 
   case class PortSpec(stages: Seq[Stage],
                       preAddress: Stageable[UInt],
+                      allowRefill : Stageable[Bool],
                       usage : AddressTranslationPortUsage,
                       pp: MmuPortParameter,
                       ss : StorageSpec,
@@ -115,6 +116,7 @@ class MmuPlugin(var spec : MmuSpec,
 
   override def newTranslationPort(stages: Seq[Stage],
                                   preAddress: Stageable[UInt],
+                                  allowRefill : Stageable[Bool],
                                   usage : AddressTranslationPortUsage,
                                   portSpec: Any,
                                   storageSpec: Any) = {
@@ -124,6 +126,7 @@ class MmuPlugin(var spec : MmuSpec,
       new PortSpec(
         stages        = stages,
         preAddress    = preAddress,
+        allowRefill   = allowRefill,
         usage         = usage,
         pp = pp,
         ss = ss,
@@ -243,7 +246,7 @@ class MmuPlugin(var spec : MmuSpec,
       val storage = storages.find(_.self == ps.ss).get
 
 
-      readStage(ALLOW_REFILL) := True
+      readStage(ALLOW_REFILL) := (if(allowRefill != null) readStage(allowRefill) else True)
       val allowRefillBypass = for(stageId <- pp.readAt to pp.ctrlAt) yield new Area{
         val stage = ps.stages(stageId)
         val reg = RegInit(True)

--- a/src/main/scala/naxriscv/misc/MmuPlugin.scala
+++ b/src/main/scala/naxriscv/misc/MmuPlugin.scala
@@ -8,6 +8,7 @@ import naxriscv.interfaces.{AddressTranslationPortUsage, AddressTranslationRsp, 
 import naxriscv.lsu.DataCachePlugin
 import naxriscv.riscv.CSR
 import naxriscv.utilities.Plugin
+import spinal.core
 import spinal.core._
 import spinal.lib._
 import spinal.lib.fsm._
@@ -509,7 +510,7 @@ class MmuPlugin(var spec : MmuSpec,
       setup.invalidatePort.rsp.valid setWhen(done.rise(False))
     }
     fetch.release()
-    refill.build()
+    core.fiber.hardFork(refill.build())
   }
 }
 

--- a/src/main/scala/naxriscv/misc/PrivilegedPlugin.scala
+++ b/src/main/scala/naxriscv/misc/PrivilegedPlugin.scala
@@ -183,6 +183,9 @@ class PrivilegedPlugin(var p : PrivilegedConfig) extends Plugin with PrivilegedS
       bus.unavailable := RegNext(ClockDomain.current.isResetActive)
       val enterHalt = running.getAheadValue().fall(False)
 
+      val reseting   = RegNext(False) init(True)
+      bus.haveReset := RegInit(False) setWhen(reseting) clearWhen(bus.ackReset)
+
       val doHalt = RegInit(False) setWhen(bus.haltReq && bus.running && !setup.debugMode) clearWhen(enterHalt)
       val doResume = bus.resume.isPending(1)
 

--- a/src/main/scala/naxriscv/misc/StaticAddressTranslationPlugin.scala
+++ b/src/main/scala/naxriscv/misc/StaticAddressTranslationPlugin.scala
@@ -33,6 +33,7 @@ class StaticAddressTranslationPlugin( var physicalWidth : Int,
 
   override def newTranslationPort(stages: Seq[Stage],
                          preAddress: Stageable[UInt],
+                         allowRefill : Stageable[Bool],
                          usage: AddressTranslationPortUsage,
                          portSpec: Any,
                          storageSpec: Any): AddressTranslationRsp = {

--- a/src/main/scala/naxriscv/platform/Litex.scala
+++ b/src/main/scala/naxriscv/platform/Litex.scala
@@ -5,7 +5,7 @@ import naxriscv.fetch._
 import naxriscv.lsu._
 import naxriscv.misc._
 import naxriscv.utilities._
-import naxriscv.compatibility.{EnforceSyncRamPhase, MultiPortWritesSymplifier}
+import naxriscv.compatibility.{EnforceSyncRamPhase, MemReadDuringWritePatcherPhase, MultiPortWritesSymplifier}
 import naxriscv.debug.EmbeddedJtagPlugin
 import naxriscv.platform.ScalaInterpreter.evaluate
 import spinal.core._
@@ -145,6 +145,7 @@ object LitexGen extends App{
   }.parse(args))
 
   val spinalConfig = SpinalConfig(inlineRom = true, targetDirectory = netlistDirectory)
+  spinalConfig.addTransformationPhase(new MemReadDuringWritePatcherPhase)
   spinalConfig.addTransformationPhase(new MultiPortWritesSymplifier)
   spinalConfig.addStandardMemBlackboxing(blackboxByteEnables)
   spinalConfig.addTransformationPhase(new EnforceSyncRamPhase)

--- a/src/main/scala/naxriscv/platform/Litex.scala
+++ b/src/main/scala/naxriscv/platform/Litex.scala
@@ -307,8 +307,10 @@ Nax : timed 5026 gametics in 4958 realtics (35.480034 fps)
       timed 5026 gametics in 3692 realtics (47.646263 fps)
       timed 5026 gametics in 3444 realtics (51.077236 fps) (no more memcpy for doom flush)
       timed 5026 gametics in 3395 realtics (51.814434 fps)
+      timed 5026 gametics in 3187 realtics (55.196110 fps) (LSU2)
       timed 5026 gametics in 2369 realtics (74.254959 fps) (-1)
       timed 5026 gametics in 2301 realtics (76.449371 fps) (-1)
+      timed 5026 gametics in 2375 realtics (74.067368 fps) (LSU2)
 Vex : timed 5026 gametics in 5606 realtics (31.378880 fps)
       timed 5026 gametics in 5238 realtics (33.583427 fps)
       timed 5026 gametics in 4866 realtics (36.150841 fps) (-1)
@@ -321,6 +323,7 @@ Nax : timed 5026 gametics in 2040 realtics (86.230392 fps)
       timed 5026 gametics in 1781 realtics (98.770355 fps)
       timed 5026 gametics in 1786 realtics (98.493843 fps)
       timed 5026 gametics in 1751 realtics (100.462593 fps)
+      timed 5026 gametics in 1737 realtics (101.272308 fps) (LSU2)
 Vex : timed 5026 gametics in 3851 realtics (45.679043 fps)
 
 no draw no blit :
@@ -561,5 +564,42 @@ I_InitFb 800x600, 3200 32bpp
 [    3.751280] Freeing unused kernel image (initmem) memory: 212K
 [    3.756451] Kernel memory protection not selected by kernel config.
 [    3.762731] Run /init as init process
+
+
+
+dri => -extension GLX ?
+lsof /usr/lib/riscv64-linux-gnu/dri/swrast_dri.so
+
+/etc/X11/xorg.conf
+Section "Extensions"
+	Option "GLX" "Disable"
+EndSection
+
+cat /var/log/Xorg.0.log
+
+cp /var/run/lightdm/root/:0 /tmp/lightdmauth
+chmod a+r /tmp/lightdmauth
+export XAUTHORITY=/tmp/lightdmauth
+export DISPLAY=unix:0
+
+xauth -f /tmp/lightdmauth
+list
+exit
+
+xdotool type root
+xdotool key Tab
+xdotool type root
+xdotool key Return
+
+
+/usr/games/chocolate-doom -iwad Doom1.WAD  -1 -nosound &
+/usr/games/openttd -v sdl -b 8bpp-optimized -s null -m null &
+SDL_NOMOUSE=1 VisualBoyAdvance -1  emu/Tetris.gb &
+
+Debian setup :
+set dns, configure eth0, enable time over internet
+enable root ssh
+disable x11 GLX extention
+enable HVC0
 
  */

--- a/src/main/scala/naxriscv/platform/SynthesisTests.scala
+++ b/src/main/scala/naxriscv/platform/SynthesisTests.scala
@@ -12,6 +12,16 @@ object SynthesisTests extends App{
 
     SpinalVerilog({
       new Component {
+        def pip[T <: Data](that : T) = KeepAttribute(RegNext(KeepAttribute(RegNext(that))))
+        val x = out(pip(OHMasking.roundRobinMasked(pip(in.Bits(width bits)), pip(in Bits(width-1 bits)))))
+//        val c = StreamFifoLowLatency(Bits(4 bits), width)
+//        c.io.push.toIo()
+//        c.io.pop.toIo()
+//        c.io.flush.toIo()
+//        val mask = in Bits(width bits)
+//        val result = out(OHMasking.firstV2(mask))
+
+
 //        val en = in Bool()
 //        val din = in Bool()
 //        val addr = in UInt(6 bits)
@@ -44,9 +54,9 @@ object SynthesisTests extends App{
 //        val din = in Bits(width bits)
 //        val dout = out((din << width) >> sel)
 
-        val sel = in UInt(log2Up(width) bits)
-        val din = in Bits(width bits)
-        val dout = out((din) >> sel)
+//        val sel = in UInt(log2Up(width) bits)
+//        val din = in Bits(width bits)
+//        val dout = out((din) >> sel)
 
       }.setDefinitionName(getRtlPath().split("\\.").head)
     })
@@ -54,7 +64,7 @@ object SynthesisTests extends App{
 
 
 
-  val rtls = List(gen(106))
+  val rtls = List(16, 32).map(gen)
 
   val targets = XilinxStdTargets().take(2)
   Bench(rtls, targets)

--- a/src/main/scala/naxriscv/prediction/DecoderPredictionPlugin.scala
+++ b/src/main/scala/naxriscv/prediction/DecoderPredictionPlugin.scala
@@ -21,7 +21,12 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
                                var pcAddAt: FrontendPlugin => Stage = _.pipeline.decoded,
                                var pcPredictionAt: FrontendPlugin => Stage = _.pipeline.decoded,
                                var applyAt : FrontendPlugin => Stage = _.pipeline.serialized,
-                               var flushOnBranch : Boolean = false) extends Plugin with DecoderPrediction{
+                               var flushOnBranch : Boolean = false,
+                               var rasDepth : Int = 16) extends Plugin with DecoderPrediction{
+
+  val RAS_PUSH_PTR = Stageable(UInt(log2Up(rasDepth) bits))
+  val RAS_POP_PTR  = Stageable(UInt(log2Up(rasDepth) bits))
+
   val setup = create early new Area{
     val frontend = getService[FrontendPlugin]
     val fetch = getService[FetchPlugin]
@@ -32,11 +37,15 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
     val priority = JumpService.Priorities.DECODE_PREDICTION
     val decodeJump = jump.createJumpInterface(priority)
     val historyPush = getService[HistoryPlugin].createPushPort(priority, DISPATCH_COUNT)
+    val decoder = getService[DecoderPlugin]
 
     frontend.retain()
     fetch.retain()
     rob.retain()
     branchContext.retain()
+
+    decoder.addDecodingToRob(RAS_PUSH_PTR)
+    decoder.addDecodingToRob(RAS_POP_PTR)
   }
 
   val logic = create late new Area{
@@ -83,7 +92,6 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
     }
 
     val ras = new Area{
-      val rasDepth = 32
       val mem = new Area{
         val stack = Mem.fill(rasDepth)(PC)
         if(GenerationFlags.simulation){
@@ -103,6 +111,15 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
       write.valid := ptr.pushIt
       write.address := ptr.push
       write.data.assignDontCare()
+
+      //Restore the RAS ptr on reschedules
+      val reschedule = commit.reschedulingPort(onCommit = false)
+      val healPush = rob.readAsyncSingle(RAS_PUSH_PTR, reschedule.robId)
+      val healPop  = rob.readAsyncSingle(RAS_POP_PTR , reschedule.robId)
+      when(reschedule.valid){
+        ptr.push := healPush
+        ptr.pop  := healPop
+      }
     }
 
 
@@ -200,6 +217,8 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
           when(DISPATCH_MASK && RAS_POP) { //WARNING use resulting DISPATCH_MASK ! (if one day things are moved around)
             ras.ptr.popIt := True
           }
+          RAS_PUSH_PTR := ras.ptr.push
+          RAS_POP_PTR  := ras.ptr.pop
         }
       }
 

--- a/src/main/scala/naxriscv/prediction/DecoderPredictionPlugin.scala
+++ b/src/main/scala/naxriscv/prediction/DecoderPredictionPlugin.scala
@@ -25,7 +25,6 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
                                var rasDepth : Int = 16) extends Plugin with DecoderPrediction{
 
   val RAS_PUSH_PTR = Stageable(UInt(log2Up(rasDepth) bits))
-  val RAS_POP_PTR  = Stageable(UInt(log2Up(rasDepth) bits))
 
   val setup = create early new Area{
     val frontend = getService[FrontendPlugin]
@@ -45,7 +44,6 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
     branchContext.retain()
 
     decoder.addDecodingToRob(RAS_PUSH_PTR)
-    decoder.addDecodingToRob(RAS_POP_PTR)
   }
 
   val logic = create late new Area{
@@ -115,7 +113,7 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
       //Restore the RAS ptr on reschedules
       val reschedule = commit.reschedulingPort(onCommit = false)
       val healPush = rob.readAsyncSingle(RAS_PUSH_PTR, reschedule.robId)
-      val healPop  = rob.readAsyncSingle(RAS_POP_PTR , reschedule.robId)
+      val healPop  = healPush-1
       when(reschedule.valid){
         ptr.push := healPush
         ptr.pop  := healPop
@@ -218,7 +216,6 @@ class DecoderPredictionPlugin( var decodeAt: FrontendPlugin => Stage = _.pipelin
             ras.ptr.popIt := True
           }
           RAS_PUSH_PTR := ras.ptr.push
-          RAS_POP_PTR  := ras.ptr.pop
         }
       }
 

--- a/src/test/cpp/naxriscv/README.md
+++ b/src/test/cpp/naxriscv/README.md
@@ -98,7 +98,7 @@ Here is a konata visualisation of the trace produced by --trace-gem5 when runnin
 
 ```shell
 cd $NAXRISCV/src/test/cpp/naxriscv
-./obj_dir/VNaxRiscv --load-elf ../../../../ext/NaxSoftware/baremetal/dhrystone/build/rv32im/dhrystone.elf --pass-symbol=pass
+./obj_dir/VNaxRiscv --load-elf ../../../../ext/NaxSoftware/baremetal/dhrystone/build/rv32ima/dhrystone.elf --pass-symbol=pass
 ```
 
 # Run a riscv-test

--- a/src/test/cpp/naxriscv/makefile
+++ b/src/test/cpp/naxriscv/makefile
@@ -9,7 +9,7 @@ SPIKE_BUILD=$(realpath ${SPIKE}/build)
 
 TRACE?=yes
 #LOCKSTEP?=yes
-ALLOCATOR_CHECKS?=yes
+ALLOCATOR_CHECKS?=no
 ADDCFLAGS += -CFLAGS -Iobj_dir
 ADDCFLAGS += -CFLAGS -I$(realpath ${SPIKE}/riscv)
 ADDCFLAGS += -CFLAGS -I$(realpath ${SPIKE}/fesvr)


### PR DESCRIPTION
- Merge store/load address pipelines to avoid having two MMU ports and also implement early data cache fill on stores instead of waiting the commit writeback.
- Store data now provided by the issue queue to remove one read port from the register file, all the logic necessary to track SQ registerfile dependencies and the store address / data join logic for commit
- Added a hazard predictor to avoid store to load hazards (especialy because of the late store data created by the above change)
- The RAS now heal its indexes on reschedule using ROB storage (not realy LSU related, but in this PR)

Overall the LUT usage is reduced by ~800 luts, while performance stay at the same level / increase a bit because of the RAS update.

https://spinalhdl.github.io/NaxRiscv-Rtd/main/NaxRiscv/memory/index.html#load-store-unite