### PR TITLE
Fix potential backpressure issue in resizer function

### DIFF
--- a/src/main/scala/naxriscv/fetch/FetchCachePlugin.scala
+++ b/src/main/scala/naxriscv/fetch/FetchCachePlugin.scala
@@ -80,7 +80,7 @@ case class FetchL1Bus(physicalWidth : Int,
     rsp.valid := rspOutputStream.valid
     rsp.data  := rspOutputStream.payload
     rsp.error := ret.rsp.error
-    rspOutputStream.ready :=  (if(withBackPresure) rspOutputStream.ready else True)
+    rspOutputStream.ready :=  (if(withBackPresure) rsp.ready else True)
   }.ret
 
   def toAxi4(): Axi4ReadOnly = new Composite(this, "toAxi4"){


### PR DESCRIPTION
The resizer function in the FetchL1Bus composite has a potential backpressure issue that can occur when the newDataWidth parameter is greater than the dataWidth parameter. This issue can cause unexpected behavior in the bus and should be fixed.