### PR TITLE
Added comment headers and other modifications for REUSE compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: CC0-1.0
+
 *.class
 *.log
 *.bak

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/assets/pipeline.png.license
+++ b/assets/pipeline.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 NaxRiscv

--- a/src/main/scala/naxriscv/utilities/AllocatorMultiPort.scala
+++ b/src/main/scala/naxriscv/utilities/AllocatorMultiPort.scala
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: MIT
+
 package naxriscv.utilities
 
 import naxriscv.Global

--- a/src/main/scala/naxriscv/utilities/DataBase.scala
+++ b/src/main/scala/naxriscv/utilities/DataBase.scala
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: MIT
+
 package naxriscv.utilities
 
 import naxriscv.Global

--- a/src/main/scala/naxriscv/utilities/DebugScratchCsrPlugin.scala
+++ b/src/main/scala/naxriscv/utilities/DebugScratchCsrPlugin.scala
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: MIT
+
 package naxriscv.utilities
 
 import naxriscv.Global.{COMMIT_COUNT, RVD, XLEN}

--- a/src/main/scala/naxriscv/utilities/DivRadix4.scala
+++ b/src/main/scala/naxriscv/utilities/DivRadix4.scala
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: MIT
+
 package naxriscv.utilities
 
 

--- a/src/main/scala/naxriscv/utilities/DocPlugin.scala
+++ b/src/main/scala/naxriscv/utilities/DocPlugin.scala
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: MIT
+
 package naxriscv.utilities
 
 import java.io.{File, PrintWriter}

--- a/src/main/scala/naxriscv/utilities/Framework.scala
+++ b/src/main/scala/naxriscv/utilities/Framework.scala
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: MIT
+
 package naxriscv.utilities
 
 import spinal.core._

--- a/src/main/scala/naxriscv/utilities/Misc.scala
+++ b/src/main/scala/naxriscv/utilities/Misc.scala
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: MIT
+
 package naxriscv.utilities
 
 import naxriscv.interfaces.RegfileSpec

--- a/src/main/scala/naxriscv/utilities/XilinxDebug.scala
+++ b/src/main/scala/naxriscv/utilities/XilinxDebug.scala
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 NaxRiscv
+#
+# SPDX-License-Identifier: MIT
+
 package naxriscv.utilities
 import naxriscv.Frontend.DISPATCH_MASK
 import naxriscv.{Frontend, ROB}

--- a/src/main/verilog/xilinx/RamXilinx.v
+++ b/src/main/verilog/xilinx/RamXilinx.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2023 NaxRiscv
+//
+// SPDX-License-Identifier: MIT
 
 module Ram_1w_1rs #(
         parameter integer wordCount = 0,


### PR DESCRIPTION
Hello,

By way of introduction, I am Jithendra with the Free Software Foundation Europe, a consortium member of the NGI0 Initiative, of which you have signed NaxRiscv up for participation and funding. Part of what is offered with your involvement with NGI0 is help from us with your project on your copyright and license management.

After a quick check on your repository, I would like to propose some updates regarding copyright and licensing information in your files. Our REUSE specifications (https://reuse.software) intend to make licensing easier with best practices to display legal information through comment headers on source files that can be easily human and machine readable. The REUSE tool makes the process of applying licenses to files and compliance checking much easier.

Instructions on how to install the REUSE tool can be found here: https://reuse.readthedocs.io/en/stable/readme.html#install

You can also check out this screencast for more instructions on how to use the REUSE tool: https://download.fsfe.org/videos/reuse/screencasts/reuse-tool.gif

The changes in this pull request have also been made for you to understand the basic ideas behind REUSE, and how adopting the REUSE practices would look like within your repository.

REUSE Features:
• SPDX copyright and license comment headers for relevant files. 
• LICENSES directory with licenses used in the repository 
• Associating copyright/licensing information through a DEP5 file in large directories. 

Files Missing Copyright and Licensing Information
I've noticed that several files in your repository already contain information about the copyright and license information for the code in that particular file. That's great! Nevertheless, the idea behind REUSE is that every single file in your repository should have a header that includes this information.

To serve as an example, I added the SPDX headers with copyright and license information to the copyrightable files in a few of the directories (namely the src/main/verilog/xilinx and src/main/scala/naxriscv/utilities the folders). This should give you an idea of how comment headers should look like in a REUSE compliant repository, and how they should be added to the other source code files in your repository.

Please also check if the personal information in these headers are correct and consistent to your knowledge. In the event that there are more copyright holders, please include them in these comment headers.

LICENSES Directory in the Root of the Project Repository
The LICENSES Folder should contain the license text of every license applicable in your repository. I included in this directory the file that contained the MIT license text.

Additionally, I included in this folder the text for the CC0 license. This is because you have files in your project that are not copyrightable, for example configuration files such as .gitignore. As the fundamental idea of REUSE is that all of your files will clearly have their copyright and licensing marked, I have applied the CC0 license to .gitignore, which is functionally identical to putting the file into the public domain.

Additionally I note that you an image file "pipeline.png" in the Assets folder. For image files, we recommend creating a .license file, where you can include the comment headers for the license and copyright information. We've added one here listing the project as the copyright holder, without a license specified. Please feel free to modify this to your needs.

I hope that you find this useful and please feel free to contact me directly at jithendra@fsfe.org if you have any questions.

Best,
Jithendra
(Free Software Foundation Europe)


