### PR TITLE
Fix wrong mask for 64 bits IO access

### DIFF
--- a/src/main/scala/naxriscv/platform/NaxriscvProbe.scala
+++ b/src/main/scala/naxriscv/platform/NaxriscvProbe.scala
@@ -263,8 +263,8 @@ class NaxriscvProbe(nax : NaxRiscv, hartId : Int){
       ioAccess.error = ioBus.rsp.error.toBoolean
       if(!ioAccess.write) {
         val offset = (ioAccess.address) & (ioBus.p.dataWidth/8-1)
-        val mask = (1l << ioAccess.size*8)-1
-        ioAccess.data = (ioBus.rsp.data.toLong >> offset*8) & mask
+        val mask = (BigInt(1) << ioAccess.size*8)-1
+        ioAccess.data = (ioBus.rsp.data.toLong >> offset*8) & mask.toLong
       }
       backends.foreach(_.ioAccess(hartId, ioAccess))
       ioAccess = null


### PR DESCRIPTION
Here is the modification that I made to the mask to have a mask that is equal to 0xFFFFFFFF for 64-bit access
- Fixes issue https://github.com/SpinalHDL/NaxRiscv/issues/84
