### PR TITLE
Updating the memory mapping for SocDemo

### DIFF
--- a/src/main/scala/naxriscv/platform/tilelinkdemo/SocDemo.scala
+++ b/src/main/scala/naxriscv/platform/tilelinkdemo/SocDemo.scala
@@ -75,7 +75,7 @@ class SocDemo(cpuCount : Int, withL2 : Boolean = true, asic : Boolean = false, x
         )
       )
     )
-    emulated.node at(0, 0x1000) of bus
+    emulated.node at(0, 0x10000000) of bus
 
     val custom = Fiber build new Area{
       val mei,sei = in Bool()


### PR DESCRIPTION
Hi,

Updated memory mapping for **SocDemo** to avoid the failure of **nax/machine** code with **SocSim**

- **Fix** https://github.com/SpinalHDL/NaxRiscv/commit/f335738370e50d5d23614150c3e8c4a85685e43a#commitcomment-144177473

Thanks :D