### PR TITLE
updated verilator chechout version from v4.216 -> v4.228

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -25,6 +25,9 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
+
       - name: Install packages
         run: source .github/workflows/tools.sh && install_packages
 

--- a/.github/workflows/tools.sh
+++ b/.github/workflows/tools.sh
@@ -11,7 +11,7 @@ install_verilator(){
   unset VERILATOR_ROOT  # For bash
   cd verilator
   git pull        # Make sure we're up-to-date
-  git checkout v4.216
+  git checkout v4.228
   autoconf        # Create ./configure script
   ./configure --prefix ~/tools
   make -j4


### PR DESCRIPTION
Info: A fix for the Github automation to work.

Sorry to make you push everytime for small things like this,
I am really trying to make this run on my NixOS,
And i cant seem to figure out where exactly is my verilated.h in the main.cpp in the test file is exactly going even though i have manually added it in the makefile.
So thought i might atleast figure out if i fix this.